### PR TITLE
Update reputation.lua

### DIFF
--- a/modules/reputation.lua
+++ b/modules/reputation.lua
@@ -541,7 +541,7 @@ module = {
 	}
 }
 
-if ns.client_version>=3 then
+if ns.client_version>=4 then
 	-- event does not exists on classic and tbc clients
 	tinsert(module.events,"QUEST_LOOT_RECEIVED")
 end


### PR DESCRIPTION
Addon fails in WOTLK Classic due to unkown event. Update version to after WOTLK