### PR TITLE
ElvUI Compability

### DIFF
--- a/modules/volume.lua
+++ b/modules/volume.lua
@@ -7,7 +7,7 @@ local C, L, I = ns.LC.color, ns.L, ns.I
 
 -- module own local variables and local cached functions --
 -----------------------------------------------------------
-local name = "Volume" -- VOLUME L["ModDesc-Volume"]
+local name = "Volume2" -- VOLUME L["ModDesc-Volume"]
 local ttName,ttColumns,tt,module,createTooltip = name.."TT",2;
 local updateBrokerButton,getSoundHardware,setSoundHardware
 local icon = "Interface\\AddOns\\"..addon.."\\media\\volume_"


### PR DESCRIPTION
Since both modules share the name and the ElvUI module being inferior in all ways imaginable I suggest this minor edit to make said module avail for the datatext feature in ElvUI so you don't have to rely on other ldb showing addons. Any other logical name could be used but this is what I came up with myself.