### PR TITLE
[Feature Request] Seasonal Caps

### DIFF
--- a/modules/currency.lua
+++ b/modules/currency.lua
@@ -244,7 +244,7 @@ local function createTooltip_AddCurrencies(currencyList)
 
 				-- cap
 				if ns.profile[name].showTotalCap and currencyInfo.maxQuantity>0 then
-					str = str .."/".. ns.FormatLargeNumber(name,currencyInfo.maxQuantity,true);
+					str = str .. (not currencyInfo.useTotalEarnedForMaxQty and "/".. ns.FormatLargeNumber(name,currencyInfo.maxQuantity,true) or "");
 
 					-- cap coloring
 					if ns.profile[name].showCapColor then
@@ -263,6 +263,18 @@ local function createTooltip_AddCurrencies(currencyList)
 					-- cap coloring
 					if ns.profile[name].showCapColor then
 						wstr = CapColor(currencyInfo.capInvert and {"red","orange","yellow","green"} or {"green","yellow","orange","red"},wstr,{nonZero=currencyInfo.quantity>0,count=currencyInfo.quantityEarnedThisWeek,maxCount=currencyInfo.maxWeeklyQuantity,capInvert=currencyInfo.capInvert});
+					end
+
+					str = wstr.." "..str;
+				end
+
+				-- season cap
+				if currencyInfo.useTotalEarnedForMaxQty then
+					local wstr = "("..ns.FormatLargeNumber(name,currencyInfo.totalEarned,true).."/"..ns.FormatLargeNumber(name,currencyInfo.maxQuantity,true)..")";
+
+					-- cap coloring
+					if ns.profile[name].showCapColor then
+						wstr = CapColor(currencyInfo.capInvert and {"red","orange","yellow","green"} or {"green","yellow","orange","red"},wstr,{nonZero=currencyInfo.quantity>0,count=currencyInfo.totalEarned,maxCount=currencyInfo.maxQuantity,capInvert=currencyInfo.capInvert});
 					end
 
 					str = wstr.." "..str;


### PR DESCRIPTION
Currencies with seasonal caps, like crests, look funny when you have `quantity/max` but not showing how much more you can get.

I copied the weekly cap code so that seasonal currencies are formatted as `(total earned/max) quantity` instead.

I also put a switch in the regular cap to prevent currencies from showing as `(total earned/max) quantity/max`.

Coloring may need to be tweaked, since 0 crests are gray, but the `(total earned/max)` part should still be colored in my opinion.

![image](https://github.com/user-attachments/assets/fec029fd-e795-4f51-ae09-199161a84e7d)