### PR TITLE
Guard uninitialized gold session balance

### DIFF
--- a/modules/gold.lua
+++ b/modules/gold.lua
@@ -415,6 +415,7 @@ if (C_Bank and C_Bank.FetchDepositedMoney and Enum and Enum.BankType and Enum.Ba
 		if not login_money then
 			initFirstUpdate()
 		end
+		if not login_money then return end
 		login_money = login_money + value
 		for _,interval in ipairs({"daily","weekly","monthly"}) do
 			local TblV1,TblV2,_date = ns.toon[name].profitv1,ns.toon[name].profitv2,Date[interval];


### PR DESCRIPTION
## Summary

- Stop warband bank hooks when the Gold module's session balance remains uninitialized.

## Root cause

`gold.lua` registers the warband bank hooks even when the Gold module is disabled. In that state, `initFirstUpdate()` returns without setting `login_money`, and `updateToonProfits()` immediately attempts arithmetic on the nil value.

## Validation

- Parsed `modules/gold.lua` successfully with `luaparser`.
- `git diff --check` passes.
- Confirmed the patch is one added guard line.

Fixes #61
Fixes #81
